### PR TITLE
chore: update GHCR docker-compose

### DIFF
--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   frontend:
     image: ghcr.io/celuma/celuma-frontend:latest
+    pull_policy: always
     ports:
       - "5173:80"
     environment:
@@ -13,6 +14,7 @@ services:
 
   db-init:
     image: ghcr.io/celuma/celuma-backend:latest
+    pull_policy: always
     environment:
       - APP_NAME=celuma
       - ENV=dev
@@ -26,6 +28,7 @@ services:
 
   backend:
     image: ghcr.io/celuma/celuma-backend:latest
+    pull_policy: always
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/celumadb
       - JWT_SECRET=your-super-secret-jwt-key-change-this-in-production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
 
   db-init:
     image: ghcr.io/celuma/celuma-backend:latest
+    pull_policy: always
     environment:
       - APP_NAME=celuma
       - ENV=dev
@@ -25,6 +26,7 @@ services:
 
   backend:
     image: ghcr.io/celuma/celuma-backend:latest
+    pull_policy: always
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/celumadb
       - JWT_SECRET=your-super-secret-jwt-key-change-this-in-production


### PR DESCRIPTION
This pull request updates both `docker-compose.yml` and `docker-compose.ghcr.yml` to ensure that the latest images are always pulled when starting services. The main change is the addition of the `pull_policy: always` directive to relevant services, which helps prevent issues caused by outdated images.

**Docker Compose configuration improvements:**

* Added `pull_policy: always` to the `frontend` service in `docker-compose.ghcr.yml` to ensure the latest frontend image is always used.
* Added `pull_policy: always` to the `db-init` and `backend` services in both `docker-compose.ghcr.yml` and `docker-compose.yml` to enforce pulling the newest backend image for initialization and API services.