### PR TITLE
ci: enhance CI workflow for Docker images; add AWS ECR support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
 
     permissions:
       contents: read
-      packages: write
+      packages: write           # keep GHCR publishing
+      id-token: write           # needed for AWS OIDC
 
     steps:
       - uses: actions/checkout@v4
@@ -23,13 +24,26 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
+      # --- GHCR login (kept as-is) ---
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image (main branch)
+      # --- NEW: Configure AWS OIDC credentials for ECR push ---
+      - name: Configure AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::385511156241:role/GitHubActionsECRPushRole
+          aws-region: mx-central-1
+
+      # --- NEW: Login to Amazon ECR (captures registry URL) ---
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image (main branch → GHCR + ECR STG)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -38,9 +52,13 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
+            # GHCR (unchanged)
             ghcr.io/${{ github.repository }}:${{ github.sha }}
             ghcr.io/${{ github.repository }}:main
             ghcr.io/${{ github.repository }}:latest
+            # ECR STG (NEW)
+            ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-frontend:stg-${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-frontend:stg-latest
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -53,10 +71,14 @@ jobs:
         run: |
           echo "### 🚀 Main Branch Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image tags:**" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository }}:${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository }}:main\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository }}:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "**GHCR tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "- ghcr.io/${{ github.repository }}:${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ghcr.io/${{ github.repository }}:main" >> $GITHUB_STEP_SUMMARY
+          echo "- ghcr.io/${{ github.repository }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**ECR (stg) tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "- ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-frontend:stg-${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-frontend:stg-latest" >> $GITHUB_STEP_SUMMARY
 
   docker-release:
     runs-on: ubuntu-latest
@@ -66,7 +88,8 @@ jobs:
 
     permissions:
       contents: read
-      packages: write
+      packages: write           # keep GHCR publishing
+      id-token: write           # needed for AWS OIDC
 
     steps:
       - uses: actions/checkout@v4
@@ -74,20 +97,34 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
+      # --- GHCR login (kept as-is) ---
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # --- NEW: Configure AWS OIDC credentials for ECR push ---
+      - name: Configure AWS (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::385511156241:role/GitHubActionsECRPushRole
+          aws-region: mx-central-1
+
+      # --- NEW: Login to Amazon ECR (captures registry URL) ---
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
       - name: Extract release version
         id: release_version
         run: |
+          # Strip leading 'v' (e.g. v1.2.3 -> 1.2.3)
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "RELEASE_TAG=$VERSION" >> $GITHUB_ENV
 
-      - name: Build and push Docker image (release tag)
+      - name: Build and push Docker image (tag → GHCR + ECR PROD)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -96,9 +133,14 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
+            # GHCR (unchanged)
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:${{ steps.release_version.outputs.version }}
             ghcr.io/${{ github.repository }}:latest
+            # ECR PROD (NEW)
+            ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:${{ github.ref_name }}
+            ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:${{ steps.release_version.outputs.version }}
+            ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:latest
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.revision=${{ github.sha }}
@@ -114,9 +156,13 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Release:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image tags:**" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository }}:${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository }}:${{ steps.release_version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`ghcr.io/${{ github.repository }}:latest\`" >> $GITHUB_STEP_SUMMARY
-
-
+          echo "**GHCR tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "- ghcr.io/${{ github.repository }}:${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ghcr.io/${{ github.repository }}:${{ steps.release_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ghcr.io/${{ github.repository }}:latest" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**ECR (prod) tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "- ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:${{ steps.release_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:latest" >> $GITHUB_STEP_SUMMARY
+          


### PR DESCRIPTION
This pull request updates the CI workflow to enable publishing Docker images to both GitHub Container Registry (GHCR) and Amazon Elastic Container Registry (ECR) for staging and production environments. The changes introduce AWS OIDC authentication, ECR login steps, and new tagging conventions for ECR images, while preserving the existing GHCR publishing process.

**AWS/ECR Integration:**

* Added `id-token: write` permission and steps to configure AWS credentials using OIDC for secure authentication with AWS. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R18) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL69-R127)
* Added new workflow steps to log in to Amazon ECR and capture the registry URL for use in subsequent image publishing steps. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR27-R46) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL69-R127)

**Docker Image Publishing:**

* Updated Docker build and push steps to publish images to both GHCR and ECR for main (staging) and release (production) branches, including new ECR-specific tags. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR55-R61) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR136-R143)

**Workflow Output Improvements:**

* Enhanced the summary output in the workflow to clearly separate and list image tags for GHCR and ECR, making it easier to identify where images are published. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL56-R81) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL117-R167)

**Minor Enhancements:**

* Added a comment to strip the leading 'v' from release tags for consistent versioning.