### PR TITLE
fix(ci): remove comments from tags block to fix tag format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,9 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            # GHCR (unchanged)
             ghcr.io/${{ github.repository }}:${{ github.sha }}
             ghcr.io/${{ github.repository }}:main
             ghcr.io/${{ github.repository }}:latest
-            # ECR STG (NEW)
             ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-frontend:stg-${{ github.sha }}
             ${{ steps.login-ecr.outputs.registry }}/celuma-stg/celuma-frontend:stg-latest
           labels: |
@@ -133,11 +131,9 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            # GHCR (unchanged)
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:${{ steps.release_version.outputs.version }}
             ghcr.io/${{ github.repository }}:latest
-            # ECR PROD (NEW)
             ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:${{ github.ref_name }}
             ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:${{ steps.release_version.outputs.version }}
             ${{ steps.login-ecr.outputs.registry }}/celuma/celuma-frontend:latest


### PR DESCRIPTION
This pull request updates the Docker image tagging in the CI workflow configuration to improve clarity and maintain consistency. The main change is the removal of inline comments marking new or unchanged registry destinations for both staging and production ECR tags.

**CI workflow configuration cleanup:**

* Removed the inline comments `# GHCR (unchanged)` and `# ECR STG (NEW)` from the Docker image tags section for the staging environment in `.github/workflows/ci.yml`, making the tags list cleaner and easier to maintain.
* Removed the inline comments `# GHCR (unchanged)` and `# ECR PROD (NEW)` from the Docker image tags section for the production environment in `.github/workflows/ci.yml`, improving readability and consistency.