### PR TITLE
fix: add bearer token to report service endpoints

### DIFF
--- a/src/services/report_service.ts
+++ b/src/services/report_service.ts
@@ -3,11 +3,20 @@ import type { ReportEnvelope } from "../models/report";
 // Config base URL API
 const base = import.meta.env.DEV ? "/api" : (import.meta.env.VITE_API_BASE_URL as string) || "/api";
 
+// Helper function to get auth token
+function getAuthToken(): string | null {
+    return localStorage.getItem("auth_token") || sessionStorage.getItem("auth_token");
+}
+
 // Save report
 export async function saveReport(report: ReportEnvelope): Promise<ReportEnvelope> {
+    const token = getAuthToken();
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers["Authorization"] = token;
+
     const res = await fetch(`${base}/v1/reports`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify(report),
     });
 
@@ -21,9 +30,13 @@ export async function saveReport(report: ReportEnvelope): Promise<ReportEnvelope
 // Save new version of report
 export async function saveReportVersion(report: ReportEnvelope): Promise<void> {
     const report_id = report.id;
+    const token = getAuthToken();
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers["Authorization"] = token;
+
     const res = await fetch(`${base}/v1/reports/${report_id}/new_version`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify(report),
     });
 
@@ -35,9 +48,13 @@ export async function saveReportVersion(report: ReportEnvelope): Promise<void> {
 
 // Get report by id
 export async function getReport(reportId: string): Promise<ReportEnvelope> {
+    const token = getAuthToken();
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (token) headers["Authorization"] = token;
+
     const res = await fetch(`${base}/v1/reports/${reportId}`, {
         method: "GET",
-        headers: { Accept: "application/json" },
+        headers,
     });
     if (!res.ok) {
         const errText = await res.text();
@@ -63,8 +80,13 @@ export async function uploadReportImage(
     form.append("file", file);
     if (caption) form.append("caption", caption);
 
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (token) headers["Authorization"] = token;
+
     const res = await fetch(`${base}/v1/laboratory/samples/${sampleId}/images`, {
         method: "POST",
+        headers,
         body: form,
     });
 
@@ -81,10 +103,15 @@ export async function deleteReportImage(
     sampleId: string,
     imageId: string
 ): Promise<void> {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (token) headers["Authorization"] = token;
+
     const res = await fetch(
         `${base}/v1/laboratory/samples/${sampleId}/images/${imageId}`,
         {
             method: "DELETE",
+            headers,
         }
     );
 
@@ -98,11 +125,15 @@ export async function deleteReportImage(
 export async function fetchReportImages(
     sampleId: string
 ): Promise<{ id: string; url: string; thumbnailUrl?: string; caption?: string }[]> {
+    const token = getAuthToken();
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (token) headers["Authorization"] = token;
+
     const res = await fetch(
         `${base}/v1/laboratory/samples/${sampleId}/images`,
         {
             method: "GET",
-            headers: { Accept: "application/json" },
+            headers,
         }
     );
 


### PR DESCRIPTION
This pull request enhances the authentication mechanism for all report-related API requests in `src/services/report_service.ts`. The main improvement is the consistent inclusion of an `Authorization` header using a token retrieved from either `localStorage` or `sessionStorage`, ensuring that all relevant endpoints are properly secured.

**Authentication improvements:**

* Added a helper function `getAuthToken()` to retrieve the authentication token from `localStorage` or `sessionStorage`.
* Updated the `saveReport`, `saveReportVersion`, and `getReport` functions to include the `Authorization` header when a token is present. [[1]](diffhunk://#diff-1b941fa4bcba5889289983cbb18bf3f350c0327db58b19743e3469ece08ec19fR6-R19) [[2]](diffhunk://#diff-1b941fa4bcba5889289983cbb18bf3f350c0327db58b19743e3469ece08ec19fR33-R39) [[3]](diffhunk://#diff-1b941fa4bcba5889289983cbb18bf3f350c0327db58b19743e3469ece08ec19fR51-R57)

**Image API enhancements:**

* Modified `uploadReportImage` and `deleteReportImage` functions to send the `Authorization` header for image uploads and deletions. [[1]](diffhunk://#diff-1b941fa4bcba5889289983cbb18bf3f350c0327db58b19743e3469ece08ec19fR83-R89) [[2]](diffhunk://#diff-1b941fa4bcba5889289983cbb18bf3f350c0327db58b19743e3469ece08ec19fR106-R114)
* Updated `fetchReportImages` to include the `Authorization` header in image fetch requests.