### PR TITLE
feat: add dashboard to home page with stats and recent activity

### DIFF
--- a/src/components/ui/recent_activity.tsx
+++ b/src/components/ui/recent_activity.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Card, List, Tag, Empty } from "antd";
+import { tokens } from "../design/tokens";
+
+interface RecentActivityItem {
+    id: string;
+    title: string;
+    description: string;
+    timestamp: string;
+    type: "order" | "report" | "sample" | "patient";
+    status?: string;
+}
+
+interface RecentActivityProps {
+    title: string;
+    items: RecentActivityItem[];
+    loading?: boolean;
+    onItemClick?: (item: RecentActivityItem) => void;
+}
+
+export default function RecentActivity({ title, items, loading = false, onItemClick }: RecentActivityProps) {
+    const cardStyle: React.CSSProperties = {
+        borderRadius: tokens.radius,
+        boxShadow: tokens.shadow,
+        background: tokens.cardBg,
+        border: "none",
+        height: "100%",
+    };
+
+    const headerStyle: React.CSSProperties = {
+        fontFamily: tokens.titleFont,
+        fontSize: 18,
+        fontWeight: 800,
+        color: "#0d1b2a",
+        margin: 0,
+        marginBottom: 16,
+    };
+
+    const getTypeColor = (type: string) => {
+        switch (type) {
+            case "order": return "#3b82f6";
+            case "report": return "#10b981";
+            case "sample": return "#f59e0b";
+            case "patient": return "#8b5cf6";
+            default: return "#6b7280";
+        }
+    };
+
+    const getStatusColor = (status: string) => {
+        switch (status?.toUpperCase()) {
+            case "PUBLISHED": return "#22c55e";
+            case "DRAFT": return "#f59e0b";
+            case "RECEIVED": return "#3b82f6";
+            case "PROCESSING": return "#8b5cf6";
+            case "COMPLETED": return "#10b981";
+            default: return "#94a3b8";
+        }
+    };
+
+    return (
+        <Card
+            loading={loading}
+            style={cardStyle}
+            bodyStyle={{ padding: 20 }}
+        >
+            <h3 style={headerStyle}>{title}</h3>
+            <List
+                dataSource={items}
+                locale={{ emptyText: <Empty description="Sin actividad reciente" /> }}
+                renderItem={(item) => (
+                    <List.Item
+                        style={{ 
+                            padding: "12px 0", 
+                            cursor: onItemClick ? "pointer" : "default",
+                            borderBottom: "1px solid #f3f4f6"
+                        }}
+                        onClick={() => onItemClick?.(item)}
+                    >
+                        <List.Item.Meta
+                            title={
+                                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                                    <span style={{ fontFamily: tokens.textFont, fontSize: 14, fontWeight: 600 }}>
+                                        {item.title}
+                                    </span>
+                                    <Tag color={getTypeColor(item.type)} style={{ fontSize: 11, margin: 0 }}>
+                                        {item.type.toUpperCase()}
+                                    </Tag>
+                                    {item.status && (
+                                        <Tag color={getStatusColor(item.status)} style={{ fontSize: 11, margin: 0 }}>
+                                            {item.status}
+                                        </Tag>
+                                    )}
+                                </div>
+                            }
+                            description={
+                                <div>
+                                    <div style={{ color: "#6b7280", fontSize: 13, marginBottom: 4 }}>
+                                        {item.description}
+                                    </div>
+                                    <div style={{ color: "#9ca3af", fontSize: 12 }}>
+                                        {new Date(item.timestamp).toLocaleString()}
+                                    </div>
+                                </div>
+                            }
+                        />
+                    </List.Item>
+                )}
+            />
+        </Card>
+    );
+}

--- a/src/components/ui/stats_card.tsx
+++ b/src/components/ui/stats_card.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Card } from "antd";
+import { tokens } from "../design/tokens";
+
+interface StatsCardProps {
+    title: string;
+    value: string | number;
+    icon?: React.ReactNode;
+    color?: string;
+    loading?: boolean;
+}
+
+export default function StatsCard({ title, value, icon, color = "#0f8b8d", loading = false }: StatsCardProps) {
+    const cardStyle: React.CSSProperties = {
+        borderRadius: tokens.radius,
+        boxShadow: tokens.shadow,
+        background: tokens.cardBg,
+        border: "none",
+        height: "100%",
+    };
+
+    const headerStyle: React.CSSProperties = {
+        fontFamily: tokens.titleFont,
+        fontSize: 16,
+        fontWeight: 600,
+        color: "#6b7280",
+        margin: 0,
+        marginBottom: 8,
+    };
+
+    const valueStyle: React.CSSProperties = {
+        fontFamily: tokens.titleFont,
+        fontSize: 32,
+        fontWeight: 800,
+        color: color,
+        margin: 0,
+        lineHeight: 1,
+    };
+
+    const iconStyle: React.CSSProperties = {
+        fontSize: 24,
+        color: color,
+        marginBottom: 8,
+    };
+
+    return (
+        <Card
+            loading={loading}
+            style={cardStyle}
+            bodyStyle={{ padding: 20 }}
+        >
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+                {icon && <div style={iconStyle}>{icon}</div>}
+                <h3 style={headerStyle}>{title}</h3>
+                <div style={valueStyle}>{value}</div>
+            </div>
+        </Card>
+    );
+}

--- a/src/hooks/use_dashboard_data.ts
+++ b/src/hooks/use_dashboard_data.ts
@@ -1,0 +1,71 @@
+import { useState, useEffect } from "react";
+
+function getApiBase(): string {
+    return import.meta.env.DEV ? "/api" : (import.meta.env.VITE_API_BASE_URL || "/api");
+}
+
+async function getJSON<TRes>(path: string): Promise<TRes> {
+    const token = localStorage.getItem("auth_token") || sessionStorage.getItem("auth_token");
+    const headers: Record<string, string> = { accept: "application/json" };
+    if (token) headers["Authorization"] = token;
+    const res = await fetch(`${getApiBase()}${path}`, { method: "GET", headers, credentials: "include" });
+    const text = await res.text();
+    let parsed: unknown = undefined;
+    try { parsed = text ? JSON.parse(text) : undefined; } catch { /* ignore */ }
+    if (!res.ok) {
+        const message = (parsed as { message?: string } | undefined)?.message ?? `${res.status} ${res.statusText}`;
+        throw new Error(message);
+    }
+    return parsed as TRes;
+}
+
+interface DashboardStats {
+    total_patients: number;
+    total_orders: number;
+    total_samples: number;
+    total_reports: number;
+    pending_orders: number;
+    draft_reports: number;
+    published_reports: number;
+}
+
+interface RecentActivityItem {
+    id: string;
+    title: string;
+    description: string;
+    timestamp: string;
+    type: "order" | "report" | "sample" | "patient";
+    status?: string;
+}
+
+interface DashboardData {
+    stats: DashboardStats;
+    recent_activity: RecentActivityItem[];
+}
+
+export function useDashboardData() {
+    const [data, setData] = useState<DashboardData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const fetchDashboardData = async () => {
+            try {
+                setLoading(true);
+                setError(null);
+
+                // Use the optimized dashboard endpoint
+                const dashboardData = await getJSON<DashboardData>("/v1/dashboard/");
+                setData(dashboardData);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : "Error al cargar los datos del dashboard");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchDashboardData();
+    }, []);
+
+    return { data, loading, error };
+}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,13 +1,38 @@
-import { Layout, Card } from "antd";
+import { Layout, Card, Row, Col, Typography } from "antd";
 import { useLocation, useNavigate } from "react-router-dom";
+import { UserOutlined, FileTextOutlined, ExperimentOutlined, BarChartOutlined } from "@ant-design/icons";
 import SidebarCeluma from "../components/ui/sidebar_menu";
 import type { CelumaKey } from "../components/ui/sidebar_menu";
+import StatsCard from "../components/ui/stats_card";
+import RecentActivity from "../components/ui/recent_activity";
+import ErrorText from "../components/ui/error_text";
+import { useDashboardData } from "../hooks/use_dashboard_data";
 import logo from "../images/celuma-isotipo.png";
 import { tokens } from "../components/design/tokens";
+
+const { Title } = Typography;
 
 const Home: React.FC = () => {
     const nav = useNavigate();
     const { pathname } = useLocation();
+    const { data, loading, error } = useDashboardData();
+
+    const handleActivityClick = (item: any) => {
+        switch (item.type) {
+            case "order":
+                nav(`/orders/${item.id}`);
+                break;
+            case "report":
+                nav(`/reports/${item.id}`);
+                break;
+            case "sample":
+                nav(`/samples/${item.id}`);
+                break;
+            case "patient":
+                nav(`/patients/${item.id}`);
+                break;
+        }
+    };
 
     return (
         <Layout style={{ minHeight: "100vh", padding: 0, margin: 0 }}>
@@ -18,13 +43,204 @@ const Home: React.FC = () => {
             />
 
             <Layout.Content style={{ padding: 24, background: tokens.bg, fontFamily: tokens.textFont }}>
-                <div style={{ maxWidth: 1000, margin: "0 auto", display: "grid", gap: tokens.gap }}>
+                <div style={{ maxWidth: 1400, margin: "0 auto", display: "grid", gap: tokens.gap }}>
+                    {/* Header */}
                     <Card
-                        title={<span style={{ fontFamily: tokens.titleFont, fontSize: 20, fontWeight: 800, color: "#0d1b2a" }}>Página de inicio</span>}
                         style={{ borderRadius: tokens.radius, boxShadow: tokens.shadow, background: tokens.cardBg }}
+                        bodyStyle={{ padding: 24 }}
                     >
-                        <p style={{ margin: 0, color: "#374151" }}>Bienvenido a la app ✨</p>
+                        <Title 
+                            level={2} 
+                            style={{ 
+                                margin: 0, 
+                                fontFamily: tokens.titleFont, 
+                                fontSize: 28, 
+                                fontWeight: 800, 
+                                color: "#0d1b2a" 
+                            }}
+                        >
+                            Dashboard
+                        </Title>
+                        <p style={{ margin: "8px 0 0 0", color: "#6b7280", fontSize: 16 }}>
+                            Resumen de información importante del laboratorio
+                        </p>
                     </Card>
+
+                    {/* Stats Cards */}
+                    <Row gutter={[16, 16]}>
+                        <Col xs={24} sm={12} lg={6}>
+                            <StatsCard
+                                title="Total Pacientes"
+                                value={data?.stats.total_patients || 0}
+                                icon={<UserOutlined />}
+                                color="#8b5cf6"
+                                loading={loading}
+                            />
+                        </Col>
+                        <Col xs={24} sm={12} lg={6}>
+                            <StatsCard
+                                title="Órdenes de Laboratorio"
+                                value={data?.stats.total_orders || 0}
+                                icon={<FileTextOutlined />}
+                                color="#3b82f6"
+                                loading={loading}
+                            />
+                        </Col>
+                        <Col xs={24} sm={12} lg={6}>
+                            <StatsCard
+                                title="Muestras Procesadas"
+                                value={data?.stats.total_samples || 0}
+                                icon={<ExperimentOutlined />}
+                                color="#f59e0b"
+                                loading={loading}
+                            />
+                        </Col>
+                        <Col xs={24} sm={12} lg={6}>
+                            <StatsCard
+                                title="Reportes Generados"
+                                value={data?.stats.total_reports || 0}
+                                icon={<BarChartOutlined />}
+                                color="#10b981"
+                                loading={loading}
+                            />
+                        </Col>
+                    </Row>
+
+                    {/* Secondary Stats */}
+                    <Row gutter={[16, 16]}>
+                        <Col xs={24} sm={8}>
+                            <StatsCard
+                                title="Órdenes Pendientes"
+                                value={data?.stats.pending_orders || 0}
+                                color="#f59e0b"
+                                loading={loading}
+                            />
+                        </Col>
+                        <Col xs={24} sm={8}>
+                            <StatsCard
+                                title="Reportes en Borrador"
+                                value={data?.stats.draft_reports || 0}
+                                color="#6b7280"
+                                loading={loading}
+                            />
+                        </Col>
+                        <Col xs={24} sm={8}>
+                            <StatsCard
+                                title="Reportes Publicados"
+                                value={data?.stats.published_reports || 0}
+                                color="#22c55e"
+                                loading={loading}
+                            />
+                        </Col>
+                    </Row>
+
+                    {/* Recent Activity */}
+                    <Row gutter={[16, 16]}>
+                        <Col xs={24} lg={12}>
+                            <RecentActivity
+                                title="Actividad Reciente"
+                                items={data?.recent_activity || []}
+                                loading={loading}
+                                onItemClick={handleActivityClick}
+                            />
+                        </Col>
+                        <Col xs={24} lg={12}>
+                            <Card
+                                style={{ borderRadius: tokens.radius, boxShadow: tokens.shadow, background: tokens.cardBg }}
+                                bodyStyle={{ padding: 20 }}
+                            >
+                                <h3 style={{ 
+                                    fontFamily: tokens.titleFont, 
+                                    fontSize: 18, 
+                                    fontWeight: 800, 
+                                    color: "#0d1b2a", 
+                                    margin: "0 0 16px 0" 
+                                }}>
+                                    Acciones Rápidas
+                                </h3>
+                                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                                    <button
+                                        onClick={() => nav("/patients/register")}
+                                        style={{
+                                            padding: "12px 16px",
+                                            border: "1px solid #e5e7eb",
+                                            borderRadius: 8,
+                                            background: "#fff",
+                                            cursor: "pointer",
+                                            textAlign: "left",
+                                            fontSize: 14,
+                                            fontWeight: 500,
+                                            color: "#374151",
+                                            transition: "all 0.2s",
+                                        }}
+                                        onMouseEnter={(e) => {
+                                            e.currentTarget.style.background = "#f9fafb";
+                                            e.currentTarget.style.borderColor = "#0f8b8d";
+                                        }}
+                                        onMouseLeave={(e) => {
+                                            e.currentTarget.style.background = "#fff";
+                                            e.currentTarget.style.borderColor = "#e5e7eb";
+                                        }}
+                                    >
+                                        📝 Registrar Nuevo Paciente
+                                    </button>
+                                    <button
+                                        onClick={() => nav("/orders/register")}
+                                        style={{
+                                            padding: "12px 16px",
+                                            border: "1px solid #e5e7eb",
+                                            borderRadius: 8,
+                                            background: "#fff",
+                                            cursor: "pointer",
+                                            textAlign: "left",
+                                            fontSize: 14,
+                                            fontWeight: 500,
+                                            color: "#374151",
+                                            transition: "all 0.2s",
+                                        }}
+                                        onMouseEnter={(e) => {
+                                            e.currentTarget.style.background = "#f9fafb";
+                                            e.currentTarget.style.borderColor = "#0f8b8d";
+                                        }}
+                                        onMouseLeave={(e) => {
+                                            e.currentTarget.style.background = "#fff";
+                                            e.currentTarget.style.borderColor = "#e5e7eb";
+                                        }}
+                                    >
+                                        🧪 Crear Nueva Orden
+                                    </button>
+                                    <button
+                                        onClick={() => nav("/reports")}
+                                        style={{
+                                            padding: "12px 16px",
+                                            border: "1px solid #e5e7eb",
+                                            borderRadius: 8,
+                                            background: "#fff",
+                                            cursor: "pointer",
+                                            textAlign: "left",
+                                            fontSize: 14,
+                                            fontWeight: 500,
+                                            color: "#374151",
+                                            transition: "all 0.2s",
+                                        }}
+                                        onMouseEnter={(e) => {
+                                            e.currentTarget.style.background = "#f9fafb";
+                                            e.currentTarget.style.borderColor = "#0f8b8d";
+                                        }}
+                                        onMouseLeave={(e) => {
+                                            e.currentTarget.style.background = "#fff";
+                                            e.currentTarget.style.borderColor = "#e5e7eb";
+                                        }}
+                                    >
+                                        📊 Ver Todos los Reportes
+                                    </button>
+                                </div>
+                            </Card>
+                        </Col>
+                    </Row>
+
+                    {/* Error Display */}
+                    {error && <ErrorText>{error}</ErrorText>}
                 </div>
             </Layout.Content>
         </Layout>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -17,7 +17,7 @@ const Home: React.FC = () => {
     const { pathname } = useLocation();
     const { data, loading, error } = useDashboardData();
 
-    const handleActivityClick = (item: any) => {
+    const handleActivityClick = (item: { id: string; type: string }) => {
         switch (item.type) {
             case "order":
                 nav(`/orders/${item.id}`);
@@ -59,7 +59,7 @@ const Home: React.FC = () => {
                                 color: "#0d1b2a" 
                             }}
                         >
-                            Dashboard
+                            Inicio
                         </Title>
                         <p style={{ margin: "8px 0 0 0", color: "#6b7280", fontSize: 16 }}>
                             Resumen de información importante del laboratorio


### PR DESCRIPTION
This pull request introduces a new, modernized dashboard experience for the home page, focusing on improved data visualization, interactivity, and maintainability. It adds reusable UI components for statistics and recent activity, implements a custom data-fetching hook for dashboard data, and completely redesigns the home page layout to provide a richer overview and quick actions for users.

The most important changes are:

**Dashboard UI and Layout Overhaul:**

* The `home.tsx` page is fully redesigned to include a dashboard header, statistics cards, recent activity, and quick action buttons, replacing the previous simple welcome card. The layout uses Ant Design's grid and card components for a modern, responsive interface.

* Quick actions are introduced, allowing users to register new patients, create new orders, or view all reports directly from the dashboard.

**Reusable UI Components:**

* Adds a new `StatsCard` component for displaying key metrics with icons and color coding, used throughout the dashboard for stats like total patients, orders, samples, and reports.

* Adds a new `RecentActivity` component to display a list of recent actions (orders, reports, samples, patients) with type/status tags and timestamps, supporting click navigation to related pages.

**Data Fetching and State Management:**

* Implements a `useDashboardData` hook to fetch all dashboard data (stats and recent activity) from a single API endpoint, handling loading and error states for the dashboard.

* Integrates the new hook and components into `home.tsx`, wiring up navigation and error display. [[1]](diffhunk://#diff-7c8d28ff1de800f1a1770a7f9bf600faa23af4ef36b2b27e7af3cc0b4b473ff4L1-R35) [[2]](diffhunk://#diff-7c8d28ff1de800f1a1770a7f9bf600faa23af4ef36b2b27e7af3cc0b4b473ff4L21-R243)

These changes collectively provide a much more informative, actionable, and visually appealing dashboard for users.

### Dashboard view
<img width="1728" height="992" alt="Captura de pantalla 2025-10-06 a la(s) 2 50 14 p m" src="https://github.com/user-attachments/assets/9ce6e025-43a6-4d3f-9225-8c57cc0e15c5" />
