### PR TITLE
fix: set fixed Host header when proxying to backend

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -10,7 +10,7 @@ server {
   location /api/ {
     proxy_pass ${BACKEND_URL};
     proxy_http_version 1.1;
-    proxy_set_header Host $host;
+    proxy_set_header Host backend;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This pull request makes a small but important configuration change to the `nginx.conf.template` file. The `Host` header in the `/api/` location block is now set to `backend` instead of passing through the original host.

- Set the `proxy_set_header Host` directive to `backend` in the `/api/` location block of `nginx.conf.template` to ensure backend services receive a consistent host header.