### PR TITLE
Update reports

### DIFF
--- a/src/components/report/report_editor.tsx
+++ b/src/components/report/report_editor.tsx
@@ -319,11 +319,13 @@ const ReportEditor: React.FC = () => {
                     }
                     setTemplate(tmpl);
 
-                    // Populate base custom values
+                    // Populate base custom values (saved value → template default → "")
                     const savedBase = full.report?.report?.base ?? {};
                     const bv: Record<string, string> = {};
                     Object.entries(tmpl.base).forEach(([k, v]) => {
-                        if (isCustomField(v)) bv[k] = (savedBase[k]?.value as string) || "";
+                        if (isCustomField(v)) {
+                            bv[k] = (savedBase[k]?.value as string) || (v as ReportBaseFieldCustom).value || "";
+                        }
                     });
                     setBaseValues(bv);
 
@@ -371,6 +373,13 @@ const ReportEditor: React.FC = () => {
                         } catch { /* ignore, use empty template */ }
                     }
                     setTemplate(tmpl);
+
+                    // Initialize base custom values with template defaults
+                    const bv: Record<string, string> = {};
+                    Object.entries(tmpl.base).forEach(([k, v]) => {
+                        if (isCustomField(v)) bv[k] = (v as ReportBaseFieldCustom).value || "";
+                    });
+                    setBaseValues(bv);
 
                     // Initialize section content with template defaults
                     const sc: Record<string, string | TemplateImageItem[]> = {};

--- a/src/components/report/report_preview_pages.tsx
+++ b/src/components/report/report_preview_pages.tsx
@@ -91,6 +91,8 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
             body.style.overflow = "hidden";
             body.style.width = `${contentWpx}px`;
             body.style.height = `${contentHpx}px`;
+            body.style.paddingTop = "4mm";
+            body.style.boxSizing = "border-box";
             body.style.background = "#ffffff";
             body.style.backgroundColor = "#ffffff";
             body.style.fontFamily = "Arial, sans-serif";
@@ -231,7 +233,7 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
             >
                 <div id="reporte-content" style={{ fontFamily: "Arial, sans-serif", fontSize: "10pt", color: "#000" }}>
 
-                    {/* Predefined base info */}
+                    {/* Predefined base info + custom fields — no gap between groups */}
                     <div style={{ marginBottom: 12 }}>
                         {predefinedFields.map(({ key, label, value }) => (
                             <p key={key} style={{ margin: "2px 0", fontSize: "10pt" }}>
@@ -239,19 +241,13 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
                                 {value || <em style={{ color: "#888" }}>Sin especificar</em>}
                             </p>
                         ))}
+                        {customFields.map(({ key, label, value }) => (
+                            <p key={key} style={{ margin: "2px 0", fontSize: "10pt" }}>
+                                <b>{label}:</b>{" "}
+                                {value || <em style={{ color: "#888" }}>Sin especificar</em>}
+                            </p>
+                        ))}
                     </div>
-
-                    {/* Custom base fields */}
-                    {customFields.length > 0 && (
-                        <div style={{ marginBottom: 12 }}>
-                            {customFields.map(({ key, label, value }) => (
-                                <p key={key} style={{ margin: "2px 0", fontSize: "10pt" }}>
-                                    <b>{label}:</b>{" "}
-                                    {value || <em style={{ color: "#888" }}>Sin especificar</em>}
-                                </p>
-                            ))}
-                        </div>
-                    )}
 
                     <hr style={{ border: "none", borderTop: "1px solid #ccc", margin: "12px 0" }} />
 

--- a/src/hooks/use_pdf_export.ts
+++ b/src/hooks/use_pdf_export.ts
@@ -43,18 +43,18 @@ export function usePdfExport() {
 <body>${pagesHtml}</body>
 </html>`;
 
-        const printWin = window.open("", "_blank");
-        if (!printWin) {
-            alert("No se pudo abrir la ventana de impresión. Permite las ventanas emergentes e intenta de nuevo.");
-            return;
-        }
+        // Create a hidden iframe — no popup window or tab is opened
+        const iframe = document.createElement("iframe");
+        iframe.style.cssText = "position:fixed;width:0;height:0;border:none;opacity:0;pointer-events:none;";
+        document.body.appendChild(iframe);
 
-        printWin.document.open();
-        printWin.document.write(htmlDoc);
-        printWin.document.close();
+        const iframeDoc = iframe.contentDocument!;
+        iframeDoc.open();
+        iframeDoc.write(htmlDoc);
+        iframeDoc.close();
 
-        // Wait for all images to finish loading in the print window
-        const imgs = Array.from(printWin.document.querySelectorAll("img"));
+        // Wait for all images inside the iframe to load
+        const imgs = Array.from(iframeDoc.querySelectorAll("img"));
         await Promise.all(
             imgs.map(
                 (img) =>
@@ -66,19 +66,20 @@ export function usePdfExport() {
             ),
         );
 
-        if ("fonts" in printWin.document) {
-            await (printWin.document as FontFaceSource & Document).fonts.ready;
+        if ("fonts" in iframeDoc) {
+            await (iframeDoc as FontFaceSource & Document).fonts.ready;
         }
 
-        // Small delay to ensure the browser finishes layout
-        await new Promise((r) => setTimeout(r, 400));
+        // Small delay to ensure layout is complete
+        await new Promise((r) => setTimeout(r, 300));
 
-        printWin.focus();
-        printWin.print();
+        iframe.contentWindow!.focus();
+        iframe.contentWindow!.print();
 
-        printWin.addEventListener("afterprint", () => {
-            printWin.close();
-        });
+        // Remove iframe after printing (afterprint) or after a fallback timeout
+        const cleanup = () => { iframe.remove(); };
+        iframe.contentWindow!.addEventListener("afterprint", cleanup, { once: true });
+        setTimeout(cleanup, 3000);
     }, []);
 
     return { exportToPDF };

--- a/src/hooks/use_pdf_export.ts
+++ b/src/hooks/use_pdf_export.ts
@@ -1,81 +1,84 @@
 import { useCallback } from "react";
-import jsPDF from "jspdf";
-import html2canvas from "html2canvas";
 import type { ReportPreviewPagesRef } from "../components/report/report_preview_pages";
 
 export function usePdfExport() {
-    const exportToPDF = useCallback(async (previewPagesRef: React.RefObject<ReportPreviewPagesRef | null>, filename?: string) => {
+    const exportToPDF = useCallback(async (
+        previewPagesRef: React.RefObject<ReportPreviewPagesRef | null>,
+        filename?: string,
+    ) => {
         const pages = previewPagesRef.current?.getPages();
         if (!pages || pages.length === 0) return;
 
-        // Make sure web fonts are loaded before rasterizing
-        if ("fonts" in document) {
-            await document.fonts.ready;
+        const safeName = (filename ?? "Reporte")
+            .replace(/[^\p{L}\p{N}_\-\s]/gu, "")
+            .trim() || "Reporte";
+
+        const pagesHtml = Array.from(pages)
+            .map((page, i) => {
+                const clone = page.cloneNode(true) as HTMLElement;
+                clone.style.boxShadow = "none";
+                clone.style.margin = "0";
+                if (i < pages.length - 1) {
+                    clone.style.pageBreakAfter = "always";
+                }
+                return clone.outerHTML;
+            })
+            .join("\n");
+
+        const htmlDoc = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>${safeName}</title>
+<style>
+  @page { size: letter; margin: 0; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    color-adjust: exact;
+  }
+</style>
+</head>
+<body>${pagesHtml}</body>
+</html>`;
+
+        const printWin = window.open("", "_blank");
+        if (!printWin) {
+            alert("No se pudo abrir la ventana de impresión. Permite las ventanas emergentes e intenta de nuevo.");
+            return;
         }
 
-        // Helper: wait for all images on a page to load
-        const waitForImages = (root: HTMLElement) => {
-            const imgs = Array.from(root.querySelectorAll("img"));
-            return Promise.all(
-                imgs.map(
-                    (img) =>
-                        new Promise<void>((resolve) => {
-                            if (img.complete && img.naturalWidth > 0) return resolve();
-                            const onDone = () => {
-                                img.removeEventListener("load", onDone);
-                                img.removeEventListener("error", onDone);
-                                resolve();
-                            };
-                            img.addEventListener("load", onDone);
-                            img.addEventListener("error", onDone);
-                        })
-                )
-            );
-        };
+        printWin.document.open();
+        printWin.document.write(htmlDoc);
+        printWin.document.close();
 
-        // Wait for pictures just in case
-        for (const page of pages) {
-            await waitForImages(page);
+        // Wait for all images to finish loading in the print window
+        const imgs = Array.from(printWin.document.querySelectorAll("img"));
+        await Promise.all(
+            imgs.map(
+                (img) =>
+                    new Promise<void>((resolve) => {
+                        if (img.complete && img.naturalWidth > 0) return resolve();
+                        img.onload = () => resolve();
+                        img.onerror = () => resolve();
+                    }),
+            ),
+        );
+
+        if ("fonts" in printWin.document) {
+            await (printWin.document as FontFaceSource & Document).fonts.ready;
         }
 
-        // Create the PDF in Letter size
-        const doc = new jsPDF({
-            unit: "mm",
-            format: "letter",
-            orientation: "portrait",
-            compress: true,
+        // Small delay to ensure the browser finishes layout
+        await new Promise((r) => setTimeout(r, 400));
+
+        printWin.focus();
+        printWin.print();
+
+        printWin.addEventListener("afterprint", () => {
+            printWin.close();
         });
-
-        // mm of the letter page
-        const PAGE_W_MM = 215.9;
-        const PAGE_H_MM = 279.4;
-
-        for (let i = 0; i < pages.length; i++) {
-            const page = pages[i];
-
-            // Rasterize the FULL PAGE as seen in preview
-            const canvas = await html2canvas(page, {
-                scale: window.devicePixelRatio || 2,
-                useCORS: true,
-                backgroundColor: "#ffffff",
-                allowTaint: true,
-                logging: false,
-                // These two options help html2canvas calculate layout as on screen
-                windowWidth: page.offsetWidth,
-                windowHeight: page.offsetHeight,
-            });
-
-            const imgData = canvas.toDataURL("image/jpeg", 0.95);
-
-            // On the 2nd+ page add new page
-            if (i > 0) doc.addPage("letter", "portrait");
-
-            // Paste the image occupying the ENTIRE page (0 margins)
-            doc.addImage(imgData, "JPEG", 0, 0, PAGE_W_MM, PAGE_H_MM);
-        }
-
-        const safeName = (filename ?? "reporte").replace(/[^a-zA-Z0-9_\-\s]/g, "").trim() || "reporte";
-        doc.save(`${safeName}.pdf`);
     }, []);
 
     return { exportToPDF };

--- a/src/pages/report_templates.tsx
+++ b/src/pages/report_templates.tsx
@@ -108,6 +108,7 @@ function EditableRow({
         <div
             style={{
                 display: "flex",
+                flexWrap: "wrap",
                 alignItems: "center",
                 gap: 8,
                 padding: "6px 8px",
@@ -117,109 +118,109 @@ function EditableRow({
                 transition: "background 0.15s",
             }}
         >
-            {/* Drag handle */}
-            <span
-                {...dragHandleProps}
-                style={{
-                    cursor: "grab",
-                    color: "#bbb",
-                    fontSize: 14,
-                    lineHeight: 1,
-                    userSelect: "none",
-                    flexShrink: 0,
-                }}
-            >
-                <HolderOutlined />
-            </span>
-
-            {/* Visibility checkbox */}
-            <Checkbox
-                checked={isVisible}
-                onChange={(e) => onToggleVisible(itemKey, e.target.checked)}
-            />
-
-            {/* Label — click to rename (custom only) */}
-            {editing ? (
-                <input
-                    ref={inputRef}
-                    value={draftLabel}
-                    autoFocus
-                    onChange={(e) => setDraftLabel(e.target.value)}
-                    onBlur={commitRename}
-                    onKeyDown={(e) => {
-                        if (e.key === "Enter") commitRename();
-                        if (e.key === "Escape") { setDraftLabel(label); setEditing(false); }
-                    }}
+            {/* Grupo izquierdo: handle + checkbox + label */}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flex: "0 0 auto", maxWidth: "100%" }}>
+                <span
+                    {...dragHandleProps}
                     style={{
-                        flex: 1,
+                        cursor: "grab",
+                        color: "#bbb",
                         fontSize: 14,
-                        border: "none",
-                        borderBottom: `2px solid ${tokens.primary}`,
-                        outline: "none",
-                        background: "transparent",
-                        minWidth: 60,
+                        lineHeight: 1,
+                        userSelect: "none",
+                        flexShrink: 0,
                     }}
-                />
-            ) : (
-                <Text
-                    style={{ flex: 1, cursor: isPredefined ? "default" : "pointer" }}
-                    onClick={() => { if (!isPredefined) { setDraftLabel(label); setEditing(true); } }}
                 >
-                    {label}
-                    {!isPredefined && (
-                        <EditOutlined style={{ marginLeft: 5, fontSize: 11, color: "#bbb" }} />
-                    )}
-                </Text>
-            )}
+                    <HolderOutlined />
+                </span>
 
-            {/* Type badge / select */}
-            {isPredefined && type && (
-                <Tag color={type === "images" ? "cyan" : "default"} style={{ fontSize: 10, margin: 0 }}>
-                    {type === "images" ? "Imágenes" : type === "richtext" ? "Texto enriquecido" : type}
-                </Tag>
-            )}
-            {!isPredefined && type && onChangeType && (
-                <Select
-                    size="small"
-                    value={type}
-                    style={{ minWidth: 110 }}
-                    onChange={(v) => onChangeType(itemKey, v as TemplateFieldType)}
-                    options={typeOptions}
-                    bordered={false}
-                    dropdownMatchSelectWidth={false}
+                <Checkbox
+                    checked={isVisible}
+                    onChange={(e) => onToggleVisible(itemKey, e.target.checked)}
                 />
-            )}
-            {!isPredefined && (
-                <Tag color="purple" style={{ fontSize: 10, margin: 0 }}>
-                    {isSection ? "Personalizada" : "Personalizado"}
-                </Tag>
-            )}
 
-            {/* Default value button — hidden for images sections */}
-            {effectiveType !== undefined && onEditDefaultValue && (
-                <Tooltip title={`${isSection ? "Contenido" : "Valor"} por defecto`}>
-                    <Button
-                        type="text"
-                        size="small"
-                        icon={<FormOutlined />}
-                        onClick={() => onEditDefaultValue(itemKey, label, effectiveType, currentValue ?? "")}
-                        style={{ color: currentValue ? tokens.primary : "#bbb", flexShrink: 0 }}
+                {editing ? (
+                    <input
+                        ref={inputRef}
+                        value={draftLabel}
+                        autoFocus
+                        onChange={(e) => setDraftLabel(e.target.value)}
+                        onBlur={commitRename}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") commitRename();
+                            if (e.key === "Escape") { setDraftLabel(label); setEditing(false); }
+                        }}
+                        style={{
+                            flex: 1,
+                            fontSize: 14,
+                            border: "none",
+                            borderBottom: `2px solid ${tokens.primary}`,
+                            outline: "none",
+                            background: "transparent",
+                            minWidth: 60,
+                        }}
                     />
-                </Tooltip>
-            )}
+                ) : (
+                <Text
+                    style={{ cursor: isPredefined ? "default" : "pointer", wordBreak: "break-word" }}
+                        onClick={() => { if (!isPredefined) { setDraftLabel(label); setEditing(true); } }}
+                    >
+                        {label}
+                        {!isPredefined && (
+                            <EditOutlined style={{ marginLeft: 5, fontSize: 11, color: "#bbb" }} />
+                        )}
+                    </Text>
+                )}
+            </div>
 
-            {/* Remove (custom only) */}
-            {!isPredefined && (
-                <Tooltip title="Eliminar">
-                    <Button
-                        type="text"
+            {/* Grupo derecho: tipo + tags + botones de acción */}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: "auto" }}>
+                {isPredefined && type && (
+                    <Tag color={type === "images" ? "cyan" : "default"} style={{ fontSize: 10, margin: 0 }}>
+                        {type === "images" ? "Imágenes" : type === "richtext" ? "Texto enriquecido" : type}
+                    </Tag>
+                )}
+                {!isPredefined && type && onChangeType && (
+                    <Select
                         size="small"
-                        danger
-                        icon={<DeleteOutlined />}
-                        onClick={() => onRemove(itemKey)}
+                        value={type}
+                        style={{ minWidth: 110 }}
+                        onChange={(v) => onChangeType(itemKey, v as TemplateFieldType)}
+                        options={typeOptions}
+                        bordered={false}
+                        dropdownMatchSelectWidth={false}
                     />
-                </Tooltip>
-            )}
+                )}
+                {!isPredefined && (
+                    <Tag color="purple" style={{ fontSize: 10, margin: 0 }}>
+                        {isSection ? "Personalizada" : "Personalizado"}
+                    </Tag>
+                )}
+
+                {effectiveType !== undefined && onEditDefaultValue && (
+                    <Tooltip title={`${isSection ? "Contenido" : "Valor"} por defecto`}>
+                        <Button
+                            type="text"
+                            size="small"
+                            icon={<FormOutlined />}
+                            onClick={() => onEditDefaultValue(itemKey, label, effectiveType, currentValue ?? "")}
+                            style={{ color: currentValue ? tokens.primary : "#bbb" }}
+                        />
+                    </Tooltip>
+                )}
+
+                {!isPredefined && (
+                    <Tooltip title="Eliminar">
+                        <Button
+                            type="text"
+                            size="small"
+                            danger
+                            icon={<DeleteOutlined />}
+                            onClick={() => onRemove(itemKey)}
+                        />
+                    </Tooltip>
+                )}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
This PR updates the reports module with improvements to template management, preview rendering, and PDF export.

**Template Management (report_templates.tsx)**

- Added support for custom base fields and sections: users can create new fields with a name and type (text, numeric, rich text, table).
- Implemented native drag & drop reordering for both base fields and sections within the template editor.
- Added a default value/content modal per field, with an editor adapted to the field type: TextArea for text, numeric Input, DatePicker for dates, ReactQuill for rich text, and TableEditor for tables.
- Rows support inline editing: labels can be renamed, types changed, and visibility toggled directly from the row.
- When loading an existing template, the saved field order is preserved and any missing predefined fields are automatically appended.

**Paginated Preview (report_preview_pages.tsx)**

- The component now renders report content across letter-size pages with fixed margins, header, and footer.
- Pagination is automatic: content flows into new pages when the current page body cannot fit it.
- table sections are converted from Markdown to HTML before rendering.
- Image sections are grouped at the end in a 3-column grid with figure captions.

**PDF Export (use_pdf_export.ts)**

- The usePdfExport hook generates PDFs using a hidden iframe (no popup windows or new tabs).
- Waits for all images and fonts inside the iframe to finish loading before calling window.print().
- The output filename is sanitized by stripping invalid characters.