### PR TITLE
Enhance loading state and implement order resolution in report components

### DIFF
--- a/src/components/auth/require_permission.tsx
+++ b/src/components/auth/require_permission.tsx
@@ -22,7 +22,7 @@ export default function RequirePermission({ permission, children }: RequirePermi
     const { authStatus, sessionExpired, hasPermission, profile } = useUserProfile();
     const location = useLocation();
 
-    if (authStatus === "loading") {
+    if (authStatus === "loading" || authStatus === "error") {
         return (
             <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "100vh" }}>
                 <Spin size="large" />

--- a/src/components/report/report_editor.tsx
+++ b/src/components/report/report_editor.tsx
@@ -23,8 +23,14 @@ import type {
     ReportEnvelope, ReportFullResponse, ReportStatus,
     ReportTemplateJSON, ReportSectionText,
     ReportBaseFieldConfig, ReportBaseFieldCustom, TemplateImageItem,
+    TemplateOrderInput,
 } from "../../models/report";
-import { buildEmptyReportContent } from "../../models/report";
+import {
+    buildEmptyReportContent,
+    normalizeReportTemplateJSON,
+    resolveBaseOrder,
+    resolveSectionOrder,
+} from "../../models/report";
 import FloatingCaptionInput from "../ui/floating_caption_input";
 import StatsCard from "../ui/stats_card";
 import { TableEditor } from "./table_editor";
@@ -89,6 +95,8 @@ function getAvatarColor(name: string): string {
 function isCustomField(f: ReportBaseFieldConfig): f is ReportBaseFieldCustom {
     return (f as ReportBaseFieldCustom).is_custom === true;
 }
+
+const EMPTY_TEMPLATE_JSON: ReportTemplateJSON = normalizeReportTemplateJSON({ base: {}, sections: {} });
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -212,21 +220,25 @@ const ReportEditor: React.FC = () => {
         [envelope?.status]
     );
 
-    // Custom base fields (from template)
+    // Custom base fields (from template), ordered by template.base_order
     const customBaseFields = useMemo(() => {
         if (!template) return [];
-        return Object.entries(template.base)
-            .filter(([, v]) => isCustomField(v))
-            .map(([k, v]) => ({ key: k, field: v as ReportBaseFieldCustom }));
+        return resolveBaseOrder(template)
+            .map((k) => {
+                const v = template.base[k];
+                return v && isCustomField(v) ? { key: k, field: v as ReportBaseFieldCustom } : null;
+            })
+            .filter((x): x is { key: string; field: ReportBaseFieldCustom } => x !== null);
     }, [template]);
 
     const hasCustomFields = customBaseFields.length > 0;
 
-    // Sections from template
+    // Sections from template, ordered by template.section_order
     const templateSections = useMemo(() => {
         if (!template) return [];
-        return Object.entries(template.sections)
-            .filter(([, v]) => v.is_visible);
+        return resolveSectionOrder(template)
+            .map((k) => [k, template.sections[k]] as const)
+            .filter(([, v]) => v?.is_visible);
     }, [template]);
 
     // Images section key
@@ -314,15 +326,16 @@ const ReportEditor: React.FC = () => {
                         }
                     }
 
-                    if (!tmpl || !tmpl.base || !tmpl.sections) {
-                        tmpl = { base: {}, sections: {} };
-                    }
-                    setTemplate(tmpl);
+                    const effectiveTmpl =
+                        !tmpl || !tmpl.base || !tmpl.sections
+                            ? EMPTY_TEMPLATE_JSON
+                            : normalizeReportTemplateJSON(tmpl);
+                    setTemplate(effectiveTmpl);
 
                     // Populate base custom values (saved value → template default → "")
                     const savedBase = full.report?.report?.base ?? {};
                     const bv: Record<string, string> = {};
-                    Object.entries(tmpl.base).forEach(([k, v]) => {
+                    Object.entries(effectiveTmpl.base).forEach(([k, v]) => {
                         if (isCustomField(v)) {
                             bv[k] = (savedBase[k]?.value as string) || (v as ReportBaseFieldCustom).value || "";
                         }
@@ -332,7 +345,7 @@ const ReportEditor: React.FC = () => {
                     // Populate section content from saved report or template defaults
                     const savedSections = full.report?.report?.sections ?? {};
                     const sc: Record<string, string | TemplateImageItem[]> = {};
-                    Object.entries(tmpl.sections).forEach(([k, v]) => {
+                    Object.entries(effectiveTmpl.sections).forEach(([k, v]) => {
                         if (v.type === "images") {
                             const saved = savedSections[k];
                             sc[k] = (saved && Array.isArray(saved.content) ? saved.content : []) as TemplateImageItem[];
@@ -361,29 +374,30 @@ const ReportEditor: React.FC = () => {
                     setFullData(pseudoFull);
 
                     // Load template via study type → template
-                    let tmpl: ReportTemplateJSON = { base: {}, sections: {} };
+                    let tmplRaw: TemplateOrderInput | null = null;
                     if (orderFull.order.study_type_id) {
                         try {
                             const st = await getStudyType(orderFull.order.study_type_id);
                             setStudyTypeName(st.name);
                             if (st.default_report_template_id) {
                                 const tpl = await getReportTemplateById(st.default_report_template_id);
-                                tmpl = tpl.template_json;
+                                tmplRaw = tpl.template_json;
                             }
                         } catch { /* ignore, use empty template */ }
                     }
-                    setTemplate(tmpl);
+                    const tmplNew = tmplRaw ? normalizeReportTemplateJSON(tmplRaw) : EMPTY_TEMPLATE_JSON;
+                    setTemplate(tmplNew);
 
                     // Initialize base custom values with template defaults
                     const bv: Record<string, string> = {};
-                    Object.entries(tmpl.base).forEach(([k, v]) => {
+                    Object.entries(tmplNew.base).forEach(([k, v]) => {
                         if (isCustomField(v)) bv[k] = (v as ReportBaseFieldCustom).value || "";
                     });
                     setBaseValues(bv);
 
                     // Initialize section content with template defaults
                     const sc: Record<string, string | TemplateImageItem[]> = {};
-                    Object.entries(tmpl.sections).forEach(([k, v]) => {
+                    Object.entries(tmplNew.sections).forEach(([k, v]) => {
                         if (v.type === "images") {
                             sc[k] = [];
                         } else {
@@ -424,7 +438,7 @@ const ReportEditor: React.FC = () => {
     // ---------------------------------------------------------------------------
 
     const buildEnvelope = useCallback((): ReportEnvelope => {
-        const tmpl = template ?? { base: {}, sections: {} };
+        const tmpl = template ?? EMPTY_TEMPLATE_JSON;
         const report = buildEmptyReportContent(tmpl);
 
         // Fill predefined base values from full data

--- a/src/components/report/report_editor.tsx
+++ b/src/components/report/report_editor.tsx
@@ -30,6 +30,7 @@ import {
     normalizeReportTemplateJSON,
     resolveBaseOrder,
     resolveSectionOrder,
+    resolveDisplayOrder,
 } from "../../models/report";
 import FloatingCaptionInput from "../ui/floating_caption_input";
 import StatsCard from "../ui/stats_card";
@@ -326,10 +327,20 @@ const ReportEditor: React.FC = () => {
                         }
                     }
 
-                    const effectiveTmpl =
+                    const baseTmpl =
                         !tmpl || !tmpl.base || !tmpl.sections
                             ? EMPTY_TEMPLATE_JSON
                             : normalizeReportTemplateJSON(tmpl);
+
+                    // Fuse the saved report's order arrays into the template state so the
+                    // editor panel and buildEnvelope both use the same effective order.
+                    const savedReport = full.report?.report;
+                    const { baseOrder: savedBO, sectionOrder: savedSO } = resolveDisplayOrder(baseTmpl, savedReport);
+                    const effectiveTmpl: ReportTemplateJSON = {
+                        ...baseTmpl,
+                        base_order: savedBO,
+                        section_order: savedSO,
+                    };
                     setTemplate(effectiveTmpl);
 
                     // Populate base custom values (saved value → template default → "")
@@ -439,7 +450,10 @@ const ReportEditor: React.FC = () => {
 
     const buildEnvelope = useCallback((): ReportEnvelope => {
         const tmpl = template ?? EMPTY_TEMPLATE_JSON;
-        const report = buildEmptyReportContent(tmpl);
+        // When a report has already been saved, preserve its stored order.
+        const { baseOrder, sectionOrder } = resolveDisplayOrder(tmpl, envelope?.report);
+        const tmplWithSavedOrder = { ...tmpl, base_order: baseOrder, section_order: sectionOrder };
+        const report = buildEmptyReportContent(tmplWithSavedOrder);
 
         // Fill predefined base values from full data
         if (fullData) {

--- a/src/components/report/report_preview_pages.tsx
+++ b/src/components/report/report_preview_pages.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, forwardRef, useImperativeHandle, type CSSProperties } from "react";
 import type { ReportEnvelope, ReportSectionText, TemplateImageItem } from "../../models/report";
+import { normalizeReportTemplateJSON, resolveBaseOrder, resolveSectionOrder } from "../../models/report";
 import { markdownTableToHtml } from "./table_utils";
 import logo from "../../images/report_logo.png";
 
@@ -186,33 +187,33 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
     // Build content from new ReportTemplateJSON structure
     // ---------------------------------------------------------------------------
 
-    const template = report.template ?? { base: {}, sections: {} };
-    const content = report.report ?? { base: {}, sections: {} };
-    // Predefined base fields visible in header area
-    const predefinedFields = Object.entries(template.base)
-        .filter(([k, v]) => PREDEFINED_BASE_KEYS.has(k) && v.is_visible)
-        .map(([k, v]) => ({
-            key: k,
-            label: v.label,
-            value: content.base[k]?.value ?? "",
-        }));
+    const tmpl = normalizeReportTemplateJSON(report.template ?? { base: {}, sections: {} });
+    const contentData = report.report ?? { base: {}, sections: {} };
 
-    // Custom base fields
-    const customFields = Object.entries(template.base)
-        .filter(([k, v]) => !PREDEFINED_BASE_KEYS.has(k) && (v as { is_custom?: boolean }).is_custom === true && v.is_visible)
-        .map(([k, v]) => ({
-            key: k,
-            label: v.label,
-            value: content.base[k]?.value ?? "",
-        }));
+    // Base header rows: single list ordered by template.base_order (predefined + custom interleaved as configured)
+    const orderedBaseRows = resolveBaseOrder(tmpl)
+        .map((k) => {
+            const v = tmpl.base[k];
+            if (!v?.is_visible) return null;
+            const isCustom = (v as { is_custom?: boolean }).is_custom === true;
+            if (!PREDEFINED_BASE_KEYS.has(k) && !isCustom) return null;
+            return {
+                key: k,
+                label: v.label,
+                value: (contentData.base[k]?.value as string) ?? "",
+            };
+        })
+        .filter((row): row is { key: string; label: string; value: string } => row !== null);
 
-    // All sections in order
-    const sections = Object.entries(template.sections)
-        .filter(([, v]) => v.is_visible)
-        .map(([k, v]) => {
-            const savedSection = content.sections[k];
+    // Sections in template.section_order
+    const sections = resolveSectionOrder(tmpl)
+        .map((k) => {
+            const v = tmpl.sections[k];
+            if (!v?.is_visible) return null;
+            const savedSection = contentData.sections[k];
             return { key: k, section: v, savedContent: savedSection };
-        });
+        })
+        .filter((row): row is { key: string; section: NonNullable<typeof tmpl.sections[string]>; savedContent: typeof contentData.sections[string] } => row !== null);
 
     // Collect all images across image sections
     const allImages: { sectionLabel: string; images: TemplateImageItem[] }[] = sections
@@ -233,15 +234,9 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
             >
                 <div id="reporte-content" style={{ fontFamily: "Arial, sans-serif", fontSize: "10pt", color: "#000" }}>
 
-                    {/* Predefined base info + custom fields — no gap between groups */}
+                    {/* Base fields in template.base_order */}
                     <div style={{ marginBottom: 12 }}>
-                        {predefinedFields.map(({ key, label, value }) => (
-                            <p key={key} style={{ margin: "2px 0", fontSize: "10pt" }}>
-                                <b>{label}:</b>{" "}
-                                {value || <em style={{ color: "#888" }}>Sin especificar</em>}
-                            </p>
-                        ))}
-                        {customFields.map(({ key, label, value }) => (
+                        {orderedBaseRows.map(({ key, label, value }) => (
                             <p key={key} style={{ margin: "2px 0", fontSize: "10pt" }}>
                                 <b>{label}:</b>{" "}
                                 {value || <em style={{ color: "#888" }}>Sin especificar</em>}

--- a/src/components/report/report_preview_pages.tsx
+++ b/src/components/report/report_preview_pages.tsx
@@ -218,14 +218,6 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
         })
         .filter((row): row is { key: string; section: NonNullable<typeof tmpl.sections[string]>; savedContent: typeof contentData.sections[string] } => row !== null);
 
-    // Collect all images across image sections
-    const allImages: { sectionLabel: string; images: TemplateImageItem[] }[] = sections
-        .filter(({ section }) => section.type === "images")
-        .map(({ section, savedContent }) => ({
-            sectionLabel: section.label,
-            images: (savedContent && Array.isArray(savedContent.content) ? savedContent.content : []) as TemplateImageItem[],
-        }))
-        .filter(({ images }) => images.length > 0);
 
     return (
         <div style={style}>
@@ -249,19 +241,8 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
 
                     <hr style={{ border: "none", borderTop: "1px solid #ccc", margin: "12px 0" }} />
 
-                    {/* Dynamic sections */}
+                    {/* Dynamic sections — rendered in section_order; images are inline at their position */}
                     {sections.map(({ key, section, savedContent }) => {
-                        if (section.type === "images") {
-                            // Images sections rendered separately below
-                            return null;
-                        }
-
-                        const rawContent = savedContent
-                            ? (savedContent as ReportSectionText).content || ""
-                            : "";
-
-                        if (!rawContent) return null;
-
                         const sectionHeader = (
                             <h3 style={{
                                 margin: "0 0 6px 0",
@@ -274,6 +255,54 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
                                 {section.label}
                             </h3>
                         );
+
+                        if (section.type === "images") {
+                            const images = (
+                                savedContent && Array.isArray(savedContent.content)
+                                    ? savedContent.content
+                                    : []
+                            ) as TemplateImageItem[];
+                            if (images.length === 0) return null;
+                            return (
+                                <div key={key} style={{ marginBottom: 14 }}>
+                                    <hr style={{ border: "none", borderTop: "1px solid #ccc", margin: "12px 0" }} />
+                                    {sectionHeader}
+                                    <div style={{
+                                        display: "grid",
+                                        gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+                                        gap: 10,
+                                    }}>
+                                        {images.map((img, idx) => (
+                                            <div key={img.id || idx} style={{
+                                                border: "1px solid #e5e7eb",
+                                                borderRadius: 6,
+                                                overflow: "hidden",
+                                                background: "#fff",
+                                            }}>
+                                                <img
+                                                    src={img.url}
+                                                    alt={img.caption || `Figura ${idx + 1}`}
+                                                    style={{ width: "100%", height: 200, objectFit: "contain", background: "#fafafa", display: "block" }}
+                                                    crossOrigin="anonymous"
+                                                />
+                                                <div style={{ padding: "5px 8px", fontSize: "9pt", borderTop: "1px solid #f0f0f0" }}>
+                                                    <b>Figura {idx + 1}.</b>{" "}
+                                                    {img.caption && img.caption.trim().length > 0
+                                                        ? img.caption
+                                                        : <em> </em>}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            );
+                        }
+
+                        const rawContent = savedContent
+                            ? (savedContent as ReportSectionText).content || ""
+                            : "";
+
+                        if (!rawContent) return null;
 
                         if (section.type === "table") {
                             return (
@@ -297,50 +326,6 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
                             </div>
                         );
                     })}
-
-                    {/* Images */}
-                    {allImages.map(({ sectionLabel, images }) => (
-                        <div key={sectionLabel} style={{ marginBottom: 14 }}>
-                            <hr style={{ border: "none", borderTop: "1px solid #ccc", margin: "12px 0" }} />
-                            <h3 style={{
-                                margin: "0 0 8px 0",
-                                fontSize: "11pt",
-                                fontWeight: 700,
-                                color: "#002060",
-                                borderBottom: "1px solid #e5e7eb",
-                                paddingBottom: 3,
-                            }}>
-                                {sectionLabel}
-                            </h3>
-                            <div style={{
-                                display: "grid",
-                                gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
-                                gap: 10,
-                            }}>
-                                {images.map((img, idx) => (
-                                    <div key={img.id || idx} style={{
-                                        border: "1px solid #e5e7eb",
-                                        borderRadius: 6,
-                                        overflow: "hidden",
-                                        background: "#fff",
-                                    }}>
-                                        <img
-                                            src={img.url}
-                                            alt={img.caption || `Figura ${idx + 1}`}
-                                            style={{ width: "100%", height: 200, objectFit: "contain", background: "#fafafa", display: "block" }}
-                                            crossOrigin="anonymous"
-                                        />
-                                        <div style={{ padding: "5px 8px", fontSize: "9pt", borderTop: "1px solid #f0f0f0" }}>
-                                            <b>Figura {idx + 1}.</b>{" "}
-                                            {img.caption && img.caption.trim().length > 0
-                                                ? img.caption
-                                                : <em> </em>}
-                                        </div>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    ))}
 
                 </div>
             </div>

--- a/src/components/report/report_preview_pages.tsx
+++ b/src/components/report/report_preview_pages.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, forwardRef, useImperativeHandle, type CSSProperties } from "react";
 import type { ReportEnvelope, ReportSectionText, TemplateImageItem } from "../../models/report";
-import { normalizeReportTemplateJSON, resolveBaseOrder, resolveSectionOrder } from "../../models/report";
+import { normalizeReportTemplateJSON, resolveDisplayOrder } from "../../models/report";
 import { markdownTableToHtml } from "./table_utils";
 import logo from "../../images/report_logo.png";
 
@@ -190,8 +190,11 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
     const tmpl = normalizeReportTemplateJSON(report.template ?? { base: {}, sections: {} });
     const contentData = report.report ?? { base: {}, sections: {} };
 
-    // Base header rows: single list ordered by template.base_order (predefined + custom interleaved as configured)
-    const orderedBaseRows = resolveBaseOrder(tmpl)
+    // Resolve effective order: content arrays take priority over template arrays (both fall back to Object.keys)
+    const { baseOrder, sectionOrder } = resolveDisplayOrder(tmpl, contentData);
+
+    // Base header rows: single list in resolved order (predefined + custom interleaved as configured)
+    const orderedBaseRows = baseOrder
         .map((k) => {
             const v = tmpl.base[k];
             if (!v?.is_visible) return null;
@@ -205,8 +208,8 @@ const ReportPreviewPages = forwardRef<ReportPreviewPagesRef, ReportPreviewPagesP
         })
         .filter((row): row is { key: string; label: string; value: string } => row !== null);
 
-    // Sections in template.section_order
-    const sections = resolveSectionOrder(tmpl)
+    // Sections in resolved order
+    const sections = sectionOrder
         .map((k) => {
             const v = tmpl.sections[k];
             if (!v?.is_visible) return null;

--- a/src/models/report.ts
+++ b/src/models/report.ts
@@ -71,6 +71,10 @@ export type ReportSectionConfig =
 export interface ReportTemplateJSON {
     base: Record<string, ReportBaseFieldConfig>;
     sections: Record<string, ReportSectionConfig>;
+    /** Display order of base field ids (source of truth; do not rely on object key order). */
+    base_order: string[];
+    /** Display order of section ids (source of truth). */
+    section_order: string[];
 }
 
 /** Template returned from GET /api/v1/reports/templates/ (list) */
@@ -213,6 +217,75 @@ export const DEFAULT_SECTIONS: Record<string, ReportSectionConfig> = {
     images:              { is_visible: true, label: "Imágenes",     type: "images",   content: [] },
 };
 
+/** Default base field ids in display order (matches DEFAULT_BASE_FIELDS insertion order). */
+export const DEFAULT_BASE_ORDER: string[] = Object.keys(DEFAULT_BASE_FIELDS);
+
+/** Default section ids in display order (matches DEFAULT_SECTIONS insertion order). */
+export const DEFAULT_SECTION_ORDER: string[] = Object.keys(DEFAULT_SECTIONS);
+
+/** Input for order resolution when `base_order` may be missing (legacy API payloads). */
+export type TemplateOrderInput = {
+    base: Record<string, ReportBaseFieldConfig>;
+    sections: Record<string, ReportSectionConfig>;
+    base_order?: string[];
+    section_order?: string[];
+};
+
+/**
+ * Canonical display order for base fields: use base_order when present and non-empty,
+ * else Object.keys(base); filter unknown ids; append any key in base missing from the list.
+ */
+export function resolveBaseOrder(t: Pick<TemplateOrderInput, "base" | "base_order">): string[] {
+    const keysInBase = Object.keys(t.base ?? {});
+    const raw = t.base_order?.length ? t.base_order : keysInBase;
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const k of raw) {
+        if (t.base[k] !== undefined && !seen.has(k)) {
+            seen.add(k);
+            result.push(k);
+        }
+    }
+    for (const k of keysInBase) {
+        if (!seen.has(k)) {
+            seen.add(k);
+            result.push(k);
+        }
+    }
+    return result;
+}
+
+/** Same as resolveBaseOrder for sections. */
+export function resolveSectionOrder(t: Pick<TemplateOrderInput, "sections" | "section_order">): string[] {
+    const keysInSections = Object.keys(t.sections ?? {});
+    const raw = t.section_order?.length ? t.section_order : keysInSections;
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const k of raw) {
+        if (t.sections[k] !== undefined && !seen.has(k)) {
+            seen.add(k);
+            result.push(k);
+        }
+    }
+    for (const k of keysInSections) {
+        if (!seen.has(k)) {
+            seen.add(k);
+            result.push(k);
+        }
+    }
+    return result;
+}
+
+/** Coerce legacy or partial API payloads into a full ReportTemplateJSON with canonical order arrays. */
+export function normalizeReportTemplateJSON(t: TemplateOrderInput): ReportTemplateJSON {
+    return {
+        base: t.base ?? {},
+        sections: t.sections ?? {},
+        base_order: resolveBaseOrder(t),
+        section_order: resolveSectionOrder(t),
+    };
+}
+
 /** Builds the default template_json skeleton used when creating a new template */
 export function buildDefaultTemplateJSON(): ReportTemplateJSON {
     return {
@@ -224,22 +297,32 @@ export function buildDefaultTemplateJSON(): ReportTemplateJSON {
             section_microscopic: { is_visible: true, label: "Microscópica", type: "richtext", content: "" },
             images:              { is_visible: true, label: "Imágenes",     type: "images",   content: [] },
         },
+        base_order: [...DEFAULT_BASE_ORDER],
+        section_order: [...DEFAULT_SECTION_ORDER],
     };
 }
 
 /** Builds an empty ReportContent from a template (same shape, content zeroed) */
 export function buildEmptyReportContent(template: ReportTemplateJSON): ReportContent {
+    const bo = resolveBaseOrder(template);
+    const so = resolveSectionOrder(template);
     return {
         base: Object.fromEntries(
-            Object.entries(template.base).map(([k, v]) => [k, { ...v, value: "" }])
+            bo.map((k) => {
+                const v = template.base[k];
+                return [k, { ...v, value: "" }];
+            })
         ) as Record<string, ReportBaseFieldConfig>,
         sections: Object.fromEntries(
-            Object.entries(template.sections).map(([k, v]) => {
+            so.map((k) => {
+                const v = template.sections[k];
                 if (v.type === "images") {
                     return [k, { ...v, content: [] as TemplateImageItem[] }];
                 }
                 return [k, { ...v, content: (v as ReportSectionText).content || "" }];
             })
         ) as Record<string, ReportSectionConfig>,
+        base_order: [...bo],
+        section_order: [...so],
     };
 }

--- a/src/models/report.ts
+++ b/src/models/report.ts
@@ -276,6 +276,25 @@ export function resolveSectionOrder(t: Pick<TemplateOrderInput, "sections" | "se
     return result;
 }
 
+/**
+ * Resolve the effective display order for a report, merging template definitions
+ * with an optional saved content order.
+ *
+ * Priority: content.base_order (if non-empty) > template.base_order > Object.keys(template.base)
+ * The template's base/sections maps are always used for metadata (labels, types, visibility).
+ */
+export function resolveDisplayOrder(
+    template: Pick<TemplateOrderInput, "base" | "sections" | "base_order" | "section_order">,
+    content?: { base_order?: string[]; section_order?: string[] } | null,
+): { baseOrder: string[]; sectionOrder: string[] } {
+    const contentBaseOrder = content?.base_order?.length ? content.base_order : undefined;
+    const contentSectionOrder = content?.section_order?.length ? content.section_order : undefined;
+    return {
+        baseOrder: resolveBaseOrder({ base: template.base, base_order: contentBaseOrder ?? template.base_order }),
+        sectionOrder: resolveSectionOrder({ sections: template.sections, section_order: contentSectionOrder ?? template.section_order }),
+    };
+}
+
 /** Coerce legacy or partial API payloads into a full ReportTemplateJSON with canonical order arrays. */
 export function normalizeReportTemplateJSON(t: TemplateOrderInput): ReportTemplateJSON {
     return {

--- a/src/pages/report_templates.tsx
+++ b/src/pages/report_templates.tsx
@@ -10,8 +10,17 @@ import type { CelumaKey } from "../components/ui/sidebar_menu";
 import logo from "../images/celuma-isotipo.png";
 import { tokens, cardTitleStyle, cardStyle } from "../components/design/tokens";
 import { getReportTemplates, getReportTemplateById, createReportTemplate, updateReportTemplate, deleteReportTemplate } from "../services/report_service";
-import type { ReportTemplateListItem, ReportTemplateJSON, ReportBaseFieldConfig, ReportBaseFieldCustom, ReportSectionConfig, ReportSectionTextCustom, TemplateFieldType } from "../models/report";
-import { buildDefaultTemplateJSON, DEFAULT_BASE_FIELDS, DEFAULT_SECTIONS } from "../models/report";
+import type {
+    ReportTemplateListItem,
+    ReportTemplateJSON,
+    ReportBaseFieldConfig,
+    ReportBaseFieldCustom,
+    ReportSectionConfig,
+    ReportSectionTextCustom,
+    TemplateFieldType,
+    TemplateOrderInput,
+} from "../models/report";
+import { buildDefaultTemplateJSON, DEFAULT_BASE_FIELDS, DEFAULT_SECTIONS, resolveBaseOrder, resolveSectionOrder } from "../models/report";
 import { TableEditor } from "../components/report/table_editor";
 
 const { TextArea } = Input;
@@ -377,14 +386,18 @@ function ReportTemplates({ embedded = false }: ReportTemplatesProps) {
     const templateJSONFromArrays = (): ReportTemplateJSON => ({
         base: Object.fromEntries(baseItems.map(({ key, cfg }) => [key, cfg])) as ReportTemplateJSON["base"],
         sections: Object.fromEntries(sectionItems.map(({ key, cfg }) => [key, cfg])) as ReportTemplateJSON["sections"],
+        base_order: baseItems.map(({ key }) => key),
+        section_order: sectionItems.map(({ key }) => key),
     });
 
-    const arraysFromTemplateJSON = (json: ReportTemplateJSON) => {
+    const arraysFromTemplateJSON = (json: ReportTemplateJSON | TemplateOrderInput) => {
+        const bo = resolveBaseOrder(json);
+        const so = resolveSectionOrder(json);
         setBaseItems(
-            Object.entries(json.base).map(([key, cfg]) => ({ key, cfg: cfg as ReportBaseFieldConfig }))
+            bo.map((key) => ({ key, cfg: json.base[key] as ReportBaseFieldConfig }))
         );
         setSectionItems(
-            Object.entries(json.sections ?? {}).map(([key, cfg]) => ({ key, cfg: cfg as ReportSectionConfig }))
+            so.map((key) => ({ key, cfg: json.sections[key] as ReportSectionConfig }))
         );
     };
 
@@ -454,7 +467,13 @@ function ReportTemplates({ embedded = false }: ReportTemplatesProps) {
             Object.entries(defaults.base).forEach(([k, v]) => { if (!mergedBase[k]) mergedBase[k] = v; });
             Object.entries(defaults.sections).forEach(([k, v]) => { if (!mergedSections[k]) mergedSections[k] = v; });
 
-            arraysFromTemplateJSON({ base: mergedBase, sections: mergedSections });
+            const storedLoose = stored as TemplateOrderInput;
+            arraysFromTemplateJSON({
+                base: mergedBase,
+                sections: mergedSections,
+                base_order: storedLoose.base_order,
+                section_order: storedLoose.section_order,
+            });
         } catch {
             message.error("Error al cargar la plantilla");
             setPanelVisible(false);


### PR DESCRIPTION
This pull request refactors the report editor and preview components to ensure that custom display orders for report fields and sections are consistently respected throughout the application. It introduces new utility functions for normalizing templates and resolving display order, and updates all relevant logic to use these mechanisms. This ensures that both the editor and the preview display fields and sections in the correct, user-defined order, rather than relying on object key order. Additionally, the rendering logic for image sections is simplified and unified.

**Template normalization and order consistency:**

- Added `base_order` and `section_order` arrays to the `ReportTemplateJSON` type to explicitly define the display order of base fields and sections, replacing reliance on object key order.
- Introduced and applied utility functions (`normalizeReportTemplateJSON`, `resolveBaseOrder`, `resolveSectionOrder`, `resolveDisplayOrder`) throughout the report editor and preview components to ensure templates are normalized and display order is resolved consistently. [[1]](diffhunk://#diff-ca08f1b2291e7c8f81fc99efd443f0abca271608425b40f8a07bad6b15f0f655R26-L27) [[2]](diffhunk://#diff-7be8b9150efe0e2732a5483adcc26645b9143282271ece59eeab09a1bccb9e7bR3)

**Report Editor updates:**

- Updated the logic for extracting and displaying custom base fields and sections to use the resolved order from the template, ensuring correct display order in the editor UI.
- When loading or initializing templates, now normalizes the template and merges any saved report-specific order arrays to maintain consistency between the editor and saved reports. [[1]](diffhunk://#diff-ca08f1b2291e7c8f81fc99efd443f0abca271608425b40f8a07bad6b15f0f655L317-R349) [[2]](diffhunk://#diff-ca08f1b2291e7c8f81fc99efd443f0abca271608425b40f8a07bad6b15f0f655L335-R359) [[3]](diffhunk://#diff-ca08f1b2291e7c8f81fc99efd443f0abca271608425b40f8a07bad6b15f0f655L364-R411)
- Updated the report envelope builder to use the resolved order when constructing new reports, ensuring that the saved report structure matches the intended display order.
- Added a constant for an empty, normalized template to reduce duplication and edge case handling.

**Report Preview updates:**

- Refactored the report preview component to use the normalized template and resolved order arrays for rendering both base fields and sections, ensuring the preview matches the editor's order. [[1]](diffhunk://#diff-7be8b9150efe0e2732a5483adcc26645b9143282271ece59eeab09a1bccb9e7bL189-L224) [[2]](diffhunk://#diff-7be8b9150efe0e2732a5483adcc26645b9143282271ece59eeab09a1bccb9e7bL236-R234)
- Simplified section rendering logic: image sections are now rendered inline in their configured order, instead of being collected and rendered separately. [[1]](diffhunk://#diff-7be8b9150efe0e2732a5483adcc26645b9143282271ece59eeab09a1bccb9e7bL254-L266) [[2]](diffhunk://#diff-7be8b9150efe0e2732a5483adcc26645b9143282271ece59eeab09a1bccb9e7bL280-R269) [[3]](diffhunk://#diff-7be8b9150efe0e2732a5483adcc26645b9143282271ece59eeab09a1bccb9e7bL345-R328)

**Other improvements:**

- Updated the `RequirePermission` component to show a loading spinner not only when authentication is loading, but also when an error occurs, improving user feedback.