### PR TITLE
Harden frontend repository and CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- What changed and why?
+
+## Validation
+
+- [ ] Lint passes
+- [ ] Unit tests pass
+- [ ] Production build passes
+- [ ] Relevant manual checks are documented
+
+## Céluma safeguards
+
+- [ ] No secrets, credentials, patient data, or tenant data are included
+- [ ] Role, permission, tenant-isolation, and audit impacts were reviewed
+- [ ] Migration, deployment, and rollback impacts are documented or not applicable
+- [ ] This PR does not mix unrelated functional and infrastructure changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 env:
   AWS_REGION: mx-central-1
 
@@ -39,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci --no-audit --no-fund
@@ -261,7 +264,9 @@ jobs:
     needs: build-npm
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    environment: prod
+    environment:
+      name: prod
+      url: https://app.celuma.mx
 
     permissions:
       id-token: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+      - celuma-1.3
+
+permissions:
+  contents: read
 
 concurrency:
   group: pr-${{ github.event.number }}
@@ -17,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -25,6 +29,9 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+      - name: Unit tests
+        run: npm test
 
       - name: Build
         env:
@@ -34,7 +41,9 @@ jobs:
   docker-pr-build:
     runs-on: ubuntu-latest
     needs: lint-build
-    if: needs.lint-build.result == 'success'
+    if: >-
+      needs.lint-build.result == 'success' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     permissions:
       contents: read
@@ -91,5 +100,3 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Docker run command:**" >> $GITHUB_STEP_SUMMARY
           echo "\`docker run -p 5173:80 ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}-latest\`" >> $GITHUB_STEP_SUMMARY
-
-

--- a/src/test/components/versioned/versioned_report_renderer_v2_parity.test.tsx
+++ b/src/test/components/versioned/versioned_report_renderer_v2_parity.test.tsx
@@ -129,7 +129,7 @@ describe("VersionedReportRendererV2 — dividers (header/footer)", () => {
 });
 
 describe("VersionedReportRendererV2 — imported ambassador letterhead: snapshot data only", () => {
-    // values ​​that imitate (but do not literally matter) those that
+    // Values that imitate (but do not literally matter) those that
     // legacy_letterhead_adapter.py would export for the Legacy letterhead — the
     // test is that this renderer treats it as normal data
     // CUALQUIER letterhead, with no special code path for them.

--- a/tests-e2e/letterhead_lifecycle.spec.ts
+++ b/tests-e2e/letterhead_lifecycle.spec.ts
@@ -130,7 +130,7 @@ test.describe("Letterhead (letterhead) lifecycle — post-Phase-2 remediation", 
 
         // A second clinical template, to prove a letterhead can be associated
         // to more than one template (step 8 of the requested flow).
-        const secondTemplate = await apiJson<{ id: string }>(request, "POST", "/api/v1/reports/templates/", {
+        await apiJson<{ id: string }>(request, "POST", "/api/v1/reports/templates/", {
             data: {
                 name: `E2E Template Two ${suffix}`,
                 template_json: { base: {}, sections: {}, base_order: [], section_order: [] },

--- a/tests-e2e/letterhead_remediation3.spec.ts
+++ b/tests-e2e/letterhead_remediation3.spec.ts
@@ -54,6 +54,11 @@ interface Lab {
     branchId: string;
 }
 
+interface LetterheadConfiguration extends Record<string, unknown> {
+    header: Record<string, unknown> & { logo_storage_id?: string };
+    footer: Record<string, unknown> & { logo_storage_id?: string };
+}
+
 /** An isolated lab with reports_v2_enabled. */
 async function createLab(request: APIRequestContext, label: string): Promise<Lab> {
     const suffix = uniqueSuffix();
@@ -202,7 +207,7 @@ test.describe("Third Remediation — Letterheads", () => {
             request, "GET", "/api/v1/report-letterheads/?active_only=false", { token: labA.token }
         );
         const sourceId = letterheads.find((l) => l.name === "Membrete Origen")!.id;
-        const activeA = await api<{ id: string; configuration: Record<string, any> }>(
+        const activeA = await api<{ id: string; configuration: LetterheadConfiguration }>(
             request, "GET", `/api/v1/report-letterheads/${sourceId}/versions/active`, { token: labA.token }
         );
         const envelope = await api<Record<string, unknown>>(
@@ -227,8 +232,8 @@ test.describe("Third Remediation — Letterheads", () => {
         expect(importedBody.status).toBe("ACTIVE");
 
         // Field-by-field equality, ignoring only StorageObject ids.
-        const scrub = (c: Record<string, any>) => {
-            const copy = JSON.parse(JSON.stringify(c));
+        const scrub = (configuration: LetterheadConfiguration): LetterheadConfiguration => {
+            const copy = structuredClone(configuration);
             copy.header.logo_storage_id = "<id>";
             copy.footer.logo_storage_id = "<id>";
             return copy;


### PR DESCRIPTION
## What changed
- applies least-privilege workflow permissions
- moves CI to Node 22
- adds 376 unit tests to the required PR check
- adds Dependabot and a Céluma safety checklist
- records the production environment URL
- fixes four pre-existing lint errors in test code

## Why
The current required check covered only lint and build, while the 1.3 test suite was not enforced and newer test dependencies require Node 22.

## Validation
- npm run lint: passes with one pre-existing warning
- npm test: 376 passed
- npm run build: passed

No functional Phase 3 scope is included.